### PR TITLE
fix: user email should be a trait

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -35,8 +35,8 @@ func (d *Connector) Asset(ctx context.Context, asset *v2.AssetRef) (string, io.R
 // Metadata returns metadata about the connector.
 func (d *Connector) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error) {
 	return &v2.ConnectorMetadata{
-		DisplayName: "My Baton Connector",
-		Description: "The template implementation of a baton connector.",
+		DisplayName: "HCP Terraform",
+		Description: "Baton connector for HCP Terraform (formerly Terraform Cloud).",
 		AccountCreationSchema: &v2.ConnectorAccountCreationSchema{
 			FieldMap: map[string]*v2.ConnectorAccountCreationSchema_Field{
 				"email": {

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -38,14 +38,19 @@ func newUserResource(user *tfe.User, parentID *v2.ResourceId) (*v2.Resource, err
 		name = user.Email + "+invited"
 	}
 
+	userTraitOptions := []resourceSdk.UserTraitOption{
+		resourceSdk.WithUserProfile(profile),
+		// last login data not available in terraform api as of 20/05/2025
+	}
+	if user.Email != "" {
+		userTraitOptions = append(userTraitOptions, resourceSdk.WithEmail(user.Email, true))
+	}
+
 	return resourceSdk.NewUserResource(
 		name,
 		userResourceType,
 		user.ID,
-		[]resourceSdk.UserTraitOption{
-			resourceSdk.WithUserProfile(profile),
-			// last login data not available in terraform api as of 20/05/2025
-		},
+		userTraitOptions,
 		resourceSdk.WithParentResourceID(parentID),
 	)
 }


### PR DESCRIPTION
#### Description

- [x] Bug fix
- [ ] New feature

Fix the missing email user trait which was preventing automatic matching against C1 directory users.

Also updated the connector name from the default/template value.