### PR TITLE
fix: mark token as isSecret in config_schema

### DIFF
--- a/cmd/baton-terraform-cloud/config.go
+++ b/cmd/baton-terraform-cloud/config.go
@@ -9,6 +9,7 @@ var (
 	TokenField = field.StringField(
 		"token",
 		field.WithDescription("The API token used to authenticate with terraform cloud."),
+		field.WithIsSecret(true),
 		field.WithRequired(true),
 	)
 


### PR DESCRIPTION
## Summary
Marks the credential field(s) **token** as `isSecret: true` so the value is treated as a secret — masked in the UI and logs and stored securely rather than in plaintext.

Found by the connector config secret-ness audit (phase 16).

`config_schema.json` is generated at build time from the Go field definitions in `cmd/baton-terraform-cloud/config.go` and is not committed to this repo, so `field.WithIsSecret(true)` is the authoritative fix.

> BREAKING: adding `isSecret: true` to these fields changes how existing
> configurations are stored. Customers with existing connector configurations
> will need to re-enter credentials after this change is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)